### PR TITLE
`ZKSProvider` trait + `zks_estimateFee` & `zks_getTestnetPaymaster` methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3770,6 +3770,7 @@ dependencies = [
 name = "zksync-web3-rs"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "clap 4.2.7",
  "env_logger",
  "ethers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,11 @@ edition = "2021"
 
 [dependencies]
 ethers = { version = "2.0.4", features = ["rustls"] }
-tokio = { version = "1", features = ["macros", "process"] }
 clap = { version = "4.2.7", features = ["derive"] }
+
+# Async
+tokio = { version = "1", features = ["macros", "process"] }
+async-trait = "0.1.68"
 
 # Serialization
 serde = "1.0.163"

--- a/src/cli/commands/call.rs
+++ b/src/cli/commands/call.rs
@@ -1,4 +1,4 @@
-use crate::cli::{commands::CHAIN_ID, ZKSyncWeb3Config};
+use crate::cli::{commands::L1_CHAIN_ID, ZKSyncWeb3Config};
 use crate::{
     prelude::{k256::ecdsa::SigningKey, MiddlewareBuilder, SignerMiddleware},
     providers::{Middleware, Provider},
@@ -49,7 +49,7 @@ pub(crate) async fn run(args: Call, config: ZKSyncWeb3Config) -> eyre::Result<()
     .interval(std::time::Duration::from_millis(10));
     if let Some(pk) = args.private_key {
         let mut signer = pk.parse::<Wallet<SigningKey>>()?;
-        signer = Wallet::with_chain_id(signer, CHAIN_ID);
+        signer = Wallet::with_chain_id(signer, L1_CHAIN_ID);
         let provider = provider.clone().with_signer(signer);
         provider.fill_transaction(&mut transaction, None).await?;
         let response: TransactionReceipt =

--- a/src/cli/commands/deploy.rs
+++ b/src/cli/commands/deploy.rs
@@ -1,4 +1,4 @@
-use crate::cli::{commands::CHAIN_ID, ZKSyncWeb3Config};
+use crate::cli::{commands::L1_CHAIN_ID, ZKSyncWeb3Config};
 use crate::{
     prelude::{k256::ecdsa::SigningKey, ContractFactory, SignerMiddleware},
     providers::Provider,
@@ -32,7 +32,7 @@ pub(crate) async fn run(args: Deploy, config: ZKSyncWeb3Config) -> eyre::Result<
         .clone();
     let (abi, bytecode, _) = contract.into_parts();
     let mut wallet = args.private_key.parse::<Wallet<SigningKey>>()?;
-    wallet = Wallet::with_chain_id(wallet, CHAIN_ID);
+    wallet = Wallet::with_chain_id(wallet, L1_CHAIN_ID);
     let provider = Provider::try_from(format!(
         "http://{host}:{port}",
         host = config.host,

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -21,4 +21,5 @@ pub(crate) use compile::CompileArgs;
 
 // It is set so that the transaction is replay-protected (EIP-155)
 // https://era.zksync.io/docs/api/hardhat/testing.html#connect-wallet-to-local-nodes
-const CHAIN_ID: u64 = 9;
+const L1_CHAIN_ID: u64 = 9;
+const L2_CHAIN_ID: u64 = 270;

--- a/src/cli/commands/pay.rs
+++ b/src/cli/commands/pay.rs
@@ -1,4 +1,5 @@
 use crate::cli::ZKSyncWeb3Config;
+use crate::zks_provider::ZKSProvider;
 use crate::{
     prelude::{k256::ecdsa::SigningKey, MiddlewareBuilder, SignerMiddleware},
     providers::{Middleware, Provider},
@@ -11,7 +12,8 @@ use crate::{
 use clap::Args;
 use eyre::ContextCompat;
 
-use super::CHAIN_ID;
+use super::L1_CHAIN_ID;
+use super::L2_CHAIN_ID;
 
 #[derive(Args)]
 pub(crate) struct Pay {
@@ -26,27 +28,53 @@ pub(crate) struct Pay {
 }
 
 pub(crate) async fn run(args: Pay, config: ZKSyncWeb3Config) -> eyre::Result<()> {
-    let signer = Wallet::with_chain_id(args.private_key, CHAIN_ID);
+    let signer = Wallet::with_chain_id(args.private_key, L2_CHAIN_ID);
     let provider = Provider::try_from(format!(
         "http://{host}:{port}",
         host = config.host,
         port = config.port
     ))?
-    .interval(std::time::Duration::from_millis(10))
-    .with_signer(signer);
+    .interval(std::time::Duration::from_millis(10));
+    let signer_middleware = provider.clone().with_signer(signer);
 
-    let payment_request = Eip1559TransactionRequest::new()
+    let mut payment_request = Eip1559TransactionRequest::new()
         .from(args.from)
         .to(args.to)
         .value(args.amount);
+
+    // Pre-fill transaction
+    let fee = provider.estimate_fee(payment_request.clone()).await?;
+    payment_request = payment_request.max_priority_fee_per_gas(fee.max_priority_fee_per_gas);
+    payment_request = payment_request.max_fee_per_gas(fee.max_fee_per_gas);
+    
     let mut transaction: TypedTransaction = payment_request.into();
     provider.fill_transaction(&mut transaction, None).await?;
+    log::debug!("Transaction request: {:?}", transaction);
+
+    log::debug!(
+        "Sender's balance before paying: {:?}",
+        provider.get_balance(args.from, None).await?
+    );
+    log::debug!(
+        "Receiver's balance before getting payed: {:?}",
+        provider.get_balance(args.to, None).await?
+    );
 
     let payment_response: TransactionReceipt =
-        SignerMiddleware::send_transaction(&provider, transaction, None)
+        SignerMiddleware::send_transaction(&signer_middleware, transaction, None)
             .await?
             .await?
             .context("No pending transaction")?;
-    log::info!("{:?}", payment_response);
+    
+    log::info!("{:#?}", payment_response.transaction_hash);
+
+    log::debug!(
+        "Sender's balance after paying: {:?}",
+        provider.get_balance(args.from, None).await?
+    );
+    log::debug!(
+        "Receiver's balance after getting payed: {:?}",
+        provider.get_balance(args.to, None).await?
+    );
     Ok(())
 }

--- a/src/cli/commands/pay.rs
+++ b/src/cli/commands/pay.rs
@@ -46,7 +46,7 @@ pub(crate) async fn run(args: Pay, config: ZKSyncWeb3Config) -> eyre::Result<()>
     let fee = provider.estimate_fee(payment_request.clone()).await?;
     payment_request = payment_request.max_priority_fee_per_gas(fee.max_priority_fee_per_gas);
     payment_request = payment_request.max_fee_per_gas(fee.max_fee_per_gas);
-    
+
     let mut transaction: TypedTransaction = payment_request.into();
     provider.fill_transaction(&mut transaction, None).await?;
     log::debug!("Transaction request: {:?}", transaction);
@@ -65,7 +65,7 @@ pub(crate) async fn run(args: Pay, config: ZKSyncWeb3Config) -> eyre::Result<()>
             .await?
             .await?
             .context("No pending transaction")?;
-    
+
     log::info!("{:#?}", payment_response.transaction_hash);
 
     log::debug!(

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use super::{output::ZKCompilationOutput, errors::ZKCompilerError};
+use super::{errors::ZKCompilerError, output::ZKCompilationOutput};
 use crate::{cli::commands, compile::traits::ZKProject, solc::Project};
 
 impl ZKProject for Project {

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -21,7 +21,6 @@ impl ZKProject {
             combined_json: Some(String::from("abi,bin")),
             standard_json: false,
         };
-        commands::compile::run(args)
-            .map_err(|e| ZKCompilerError::CompilationError(e.to_string()))
+        commands::compile::run(args).map_err(|e| ZKCompilerError::CompilationError(e.to_string()))
     }
 }

--- a/src/compile/traits.rs
+++ b/src/compile/traits.rs
@@ -1,4 +1,4 @@
-use super::{output::ZKCompilationOutput, errors::ZKCompilerError};
+use super::{errors::ZKCompilerError, output::ZKCompilationOutput};
 
 pub trait ZKProject {
     fn compile_zk(&self) -> Result<ZKCompilationOutput, ZKCompilerError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ pub mod prelude {
 // TODO: This should be visible only for this crate and not for the library users.
 pub mod cli;
 pub mod compile;
+pub mod zks_provider;
 
 // For macro expansions only, not public API.
 #[allow(unused_extern_crates)]

--- a/src/zks_provider/mod.rs
+++ b/src/zks_provider/mod.rs
@@ -1,0 +1,65 @@
+use async_trait::async_trait;
+use ethers::providers::{JsonRpcClient, Provider, ProviderError};
+use serde::Serialize;
+use std::fmt::Debug;
+
+pub mod types;
+use types::Fee;
+
+/// This trait wraps every JSON-RPC call specified in zkSync Era's documentation
+/// https://era.zksync.io/docs/api/api.html#zksync-era-json-rpc-methods
+#[async_trait]
+pub trait ZKSProvider {
+    /// Returns the fee for the transaction.
+    async fn estimate_fee<T>(&self, transaction: T) -> Result<Fee, ProviderError>
+    where
+        T: Debug + Serialize + Send + Sync;
+}
+
+#[async_trait]
+impl<P: JsonRpcClient> ZKSProvider for Provider<P> {
+    async fn estimate_fee<T>(&self, transaction: T) -> Result<Fee, ProviderError>
+    where
+        T: Debug + Serialize + Send + Sync,
+    {
+        self.request("zks_estimateFee", [transaction]).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::zks_provider::ZKSProvider;
+    use ethers::providers::Provider;
+    use serde::{Deserialize, Serialize};
+
+    #[tokio::test]
+    async fn test_estimate_fee() {
+        let provider = Provider::try_from(format!(
+            "http://{host}:{port}",
+            host = "65.108.204.116",
+            port = 3_050_i32
+        ))
+        .unwrap()
+        .interval(std::time::Duration::from_millis(10));
+
+        #[derive(Serialize, Deserialize, Debug)]
+        struct TestTransaction {
+            from: String,
+            to: String,
+            data: String,
+        }
+
+        let transaction = TestTransaction {
+            from: "0x1111111111111111111111111111111111111111".to_owned(),
+            to: "0x2222222222222222222222222222222222222222".to_owned(),
+            data: "0x608060405234801561001057600080fd5b50610228806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c80639146769014610030575b600080fd5b61003861004e565b6040516100459190610170565b60405180910390f35b60606000805461005d906101c1565b80601f0160208091040260200160405190810160405280929190818152602001828054610089906101c1565b80156100d65780601f106100ab576101008083540402835291602001916100d6565b820191906000526020600020905b8154815290600101906020018083116100b957829003601f168201915b5050505050905090565b600081519050919050565b600082825260208201905092915050565b60005b8381101561011a5780820151818401526020810190506100ff565b60008484015250505050565b6000601f19601f8301169050919050565b6000610142826100e0565b61014c81856100eb565b935061015c8185602086016100fc565b61016581610126565b840191505092915050565b6000602082019050818103600083015261018a8184610137565b905092915050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052602260045260246000fd5b600060028204905060018216806101d957607f821691505b6020821081036101ec576101eb610192565b5b5091905056fea26469706673582212203d7f62ad5ef1f9670aa630c438f1a75844e1d2cfaf92e6985c698b7009e3dfa864736f6c63430008140033".to_owned(),
+        };
+
+        let estimated_fee = provider.estimate_fee(transaction).await.unwrap();
+
+        assert_eq!(estimated_fee.gas_limit.as_u64(), 162436);
+        assert_eq!(estimated_fee.gas_per_pubdata_limit.as_u64(), 66);
+        assert_eq!(estimated_fee.max_fee_per_gas.as_u64(), 250000000);
+        assert_eq!(estimated_fee.max_priority_fee_per_gas.as_u64(), 0);
+    }
+}

--- a/src/zks_provider/types/fee.rs
+++ b/src/zks_provider/types/fee.rs
@@ -1,0 +1,12 @@
+use ethers::types::U256;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Fee {
+    pub gas_limit: U256,
+    pub gas_per_pubdata_limit: U256,
+    pub max_fee_per_gas: U256,
+    pub max_priority_fee_per_gas: U256,
+}
+
+impl Copy for Fee {}

--- a/src/zks_provider/types/mod.rs
+++ b/src/zks_provider/types/mod.rs
@@ -1,0 +1,2 @@
+pub mod fee;
+pub use fee::Fee;


### PR DESCRIPTION
## Features

- `ZKSProvider` trait: this trait wraps every JSON-RPC call specified in [zkSync Era's documentation](https://era.zksync.io/docs/api/api.html#zksync-era-json-rpc-methods).
- `zks_estimateFee` method: returns the fee for the transaction (more details [here](https://era.zksync.io/docs/api/api.html#zksync-era-json-rpc-methods)).