### PR TITLE
Fix exports from ethers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ethers = { version = "2.0.4", features = ["rustls"] }
+ethers = { version = "2.0.4", features = ["rustls", "ethers-solc"] }
 clap = { version = "4.2.7", features = ["derive"] }
 
 # Async

--- a/examples/simple_payment/main.rs
+++ b/examples/simple_payment/main.rs
@@ -30,7 +30,11 @@ struct Args {
     pub to: Address,
     #[clap(long, name = "SENDER_PRIVATE_KEY")]
     pub private_key: Wallet<SigningKey>,
-    #[clap(long, name = "NETWORK_NAME", help = "Available networks: \"era\" or \"eth\"")]
+    #[clap(
+        long,
+        name = "NETWORK_NAME",
+        help = "Available networks: \"era\" or \"eth\""
+    )]
     pub network: String,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ pub mod prelude {
 
     pub use super::contract::*;
 
+    pub use super::core::types::transaction::eip2718::TypedTransaction;
     pub use super::core::{types::*, *};
 
     pub use super::etherscan::*;
@@ -68,6 +69,8 @@ pub mod prelude {
 
     pub use super::solc::*;
 }
+
+pub use prelude::*;
 
 // TODO: This should be visible only for this crate and not for the library users.
 pub mod cli;


### PR DESCRIPTION
For the users to use our lib and have all the functionalities like we planned we need to add the `prelude` as a public module.
Ethers need the feature `ethers-solc` to correctly export the `solc` module.