### PR TITLE
Support Yul compilation (`bin` & `asm`)

### DIFF
--- a/src/cli/commands/compile.rs
+++ b/src/cli/commands/compile.rs
@@ -1,6 +1,6 @@
 use crate::compile::{constants, output::ZKSCompilationOutput};
 use clap::Parser;
-use std::{path::PathBuf, borrow::Cow};
+use std::{borrow::Cow, path::PathBuf};
 
 #[derive(Parser)]
 pub struct CompileArgs {
@@ -13,7 +13,12 @@ pub struct CompileArgs {
     pub combined_json: Option<String>,
     #[clap(long, action)]
     pub standard_json: bool,
-    #[clap(long, action, conflicts_with = "standard-json", conflicts_with = "combined-json")]
+    #[clap(
+        long,
+        action,
+        conflicts_with = "standard-json",
+        conflicts_with = "combined-json"
+    )]
     pub yul: bool,
     #[clap(long, action)]
     pub system_mode: bool,
@@ -80,7 +85,10 @@ pub(crate) fn run(args: CompileArgs) -> eyre::Result<String> {
 
     let command_output = command.output()?;
 
-    let compilation_output = String::from_utf8_lossy(&command_output.stdout).into_owned().trim().to_string();
+    let compilation_output = String::from_utf8_lossy(&command_output.stdout)
+        .into_owned()
+        .trim()
+        .to_string();
 
     log::info!("{compilation_output:?}");
 

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -22,7 +22,12 @@ impl ZKProject {
             solc: Path::new(constants::SOLC_PATH).canonicalize().ok(),
             combined_json: Some(String::from("abi,bin")),
             standard_json: false,
+            yul: false,
+            system_mode: false,
+            bin: false,
+            asm: false,
         };
-        commands::compile::run(args).map_err(|e| ZKCompilerError::CompilationError(e.to_string()))
+        let command_output = commands::compile::run(args).map_err(|e| ZKCompilerError::CompilationError(e.to_string()))?;
+        serde_json::from_str(&command_output).map_err(|e| ZKCompilerError::CompilationError(e.to_string()))
     }
 }

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -27,7 +27,9 @@ impl ZKProject {
             bin: false,
             asm: false,
         };
-        let command_output = commands::compile::run(args).map_err(|e| ZKCompilerError::CompilationError(e.to_string()))?;
-        serde_json::from_str(&command_output).map_err(|e| ZKCompilerError::CompilationError(e.to_string()))
+        let command_output = commands::compile::run(args)
+            .map_err(|e| ZKCompilerError::CompilationError(e.to_string()))?;
+        serde_json::from_str(&command_output)
+            .map_err(|e| ZKCompilerError::CompilationError(e.to_string()))
     }
 }


### PR DESCRIPTION
## Installation

```
make cli
```

## Usage

> Disclaimer: the `--solc` path will change.

### To bytecode

```
zksync-web3-rs compile --contract-paths <YUL_CONTRACT_PATH> --solc src/compile/solc-macos --yul --system-mode --bin
```

### To assembly

```
zksync-web3-rs compile --contract-paths <YUL_CONTRACT_PATH> --solc src/compile/solc-macos --yul --system-mode --asm
```