### PR TITLE
Add feature flag for importing `ethers-solc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ env_logger = "0.10"
 # Hash
 sha2 = "0.9.5"
 
+[features]
+ethers-solc = ["ethers/ethers-solc"]
+
 # Examples
 
 [[example]]


### PR DESCRIPTION
Although the goal of the SDK is not to provide any compile features, its purpose is to re-export ethers-rs. To maintain consistency with `ethers-rs`, this PR adds the feature flag `ethers-solc`, which allows `ethers-rs` to include `ethers-solc`.





