### PR TITLE
Use `PendingTransaction` struct in every operation

### DIFF
--- a/src/zks_provider/mod.rs
+++ b/src/zks_provider/mod.rs
@@ -16,6 +16,7 @@ use ethers::{
         U64,
     },
 };
+use ethers_contract::providers::PendingTransaction;
 use serde::Serialize;
 use serde_json::json;
 use std::{collections::HashMap, fmt::Debug, time::Duration};
@@ -41,6 +42,9 @@ use self::types::{
 /// https://era.zksync.io/docs/api/api.html#zksync-era-json-rpc-methods
 #[async_trait]
 pub trait ZKSProvider {
+    type Provider: JsonRpcClient;
+    type ZKProvider: JsonRpcClient;
+
     async fn zk_estimate_gas<T>(&self, transaction: T) -> Result<U256, ProviderError>
     where
         T: Debug + Serialize + Send + Sync;
@@ -193,7 +197,7 @@ pub trait ZKSProvider {
         function_signature: &str,
         function_parameters: Option<Vec<String>>,
         overrides: Option<Overrides>,
-    ) -> Result<(Vec<Token>, H256), ProviderError>
+    ) -> Result<PendingTransaction<Self::ZKProvider>, ProviderError>
     where
         D: PrehashSigner<(RecoverableSignature, RecoveryId)> + Send + Sync;
 
@@ -204,7 +208,7 @@ pub trait ZKSProvider {
         function_signature: &str,
         function_parameters: Option<Vec<String>>,
         overrides: Option<Overrides>,
-    ) -> Result<(Vec<Token>, H256), ProviderError>
+    ) -> Result<PendingTransaction<Self::Provider>, ProviderError>
     where
         D: PrehashSigner<(RecoverableSignature, RecoveryId)> + Send + Sync;
 
@@ -225,6 +229,9 @@ pub trait ZKSProvider {
 
 #[async_trait]
 impl<M: Middleware + ZKSProvider, S: Signer> ZKSProvider for SignerMiddleware<M, S> {
+    type Provider = <M as Middleware>::Provider;
+    type ZKProvider = <M as ZKSProvider>::ZKProvider;
+
     async fn zk_estimate_gas<T>(&self, transaction: T) -> Result<U256, ProviderError>
     where
         T: Debug + Serialize + Send + Sync,
@@ -399,7 +406,7 @@ impl<M: Middleware + ZKSProvider, S: Signer> ZKSProvider for SignerMiddleware<M,
         function_signature: &str,
         function_parameters: Option<Vec<String>>,
         overrides: Option<Overrides>,
-    ) -> Result<(Vec<Token>, H256), ProviderError>
+    ) -> Result<PendingTransaction<Self::ZKProvider>, ProviderError>
     where
         D: PrehashSigner<(RecoverableSignature, RecoveryId)> + Send + Sync,
     {
@@ -421,7 +428,7 @@ impl<M: Middleware + ZKSProvider, S: Signer> ZKSProvider for SignerMiddleware<M,
         function_signature: &str,
         function_parameters: Option<Vec<String>>,
         _overrides: Option<Overrides>,
-    ) -> Result<(Vec<Token>, H256), ProviderError>
+    ) -> Result<PendingTransaction<Self::Provider>, ProviderError>
     where
         D: PrehashSigner<(RecoverableSignature, RecoveryId)> + Send + Sync,
     {
@@ -434,18 +441,9 @@ impl<M: Middleware + ZKSProvider, S: Signer> ZKSProvider for SignerMiddleware<M,
             _overrides,
         )
         .await?;
-        let pending_transaction = self
-            .send_transaction(tx, None)
+        self.send_transaction(tx, None)
             .await
-            .map_err(|e| ProviderError::CustomError(format!("Error sending transaction: {e:?}")))?;
-
-        let transaction_receipt = pending_transaction
-            .await?
-            .ok_or(ProviderError::CustomError(
-                "no transaction receipt".to_owned(),
-            ))?;
-
-        Ok((Vec::new(), transaction_receipt.transaction_hash))
+            .map_err(|e| ProviderError::CustomError(format!("Error sending transaction: {e:?}")))
     }
 
     async fn wait_for_finalize(
@@ -481,6 +479,9 @@ impl<M: Middleware + ZKSProvider, S: Signer> ZKSProvider for SignerMiddleware<M,
 
 #[async_trait]
 impl<P: JsonRpcClient> ZKSProvider for Provider<P> {
+    type Provider = P;
+    type ZKProvider = P;
+
     async fn zk_estimate_gas<T>(&self, transaction: T) -> Result<U256, ProviderError>
     where
         T: Debug + Serialize + Send + Sync,
@@ -692,7 +693,7 @@ impl<P: JsonRpcClient> ZKSProvider for Provider<P> {
         function_signature: &str,
         function_parameters: Option<Vec<String>>,
         overrides: Option<Overrides>,
-    ) -> Result<(Vec<Token>, H256), ProviderError>
+    ) -> Result<PendingTransaction<Self::ZKProvider>, ProviderError>
     where
         D: PrehashSigner<(RecoverableSignature, RecoveryId)> + Send + Sync,
     {
@@ -751,22 +752,12 @@ impl<P: JsonRpcClient> ZKSProvider for Provider<P> {
         send_request =
             send_request.custom_data(Eip712Meta::new().custom_signature(signature.to_vec()));
 
-        let pending_transaction = self
-            .send_raw_transaction(
-                [&[EIP712_TX_TYPE], &*send_request.rlp_unsigned()]
-                    .concat()
-                    .into(),
-            )
-            .await?;
-
-        let transaction_receipt = pending_transaction
-            .await?
-            .ok_or(ProviderError::CustomError(
-                "no transaction receipt".to_owned(),
-            ))?;
-
-        // TODO: decode function output.
-        Ok((Vec::new(), transaction_receipt.transaction_hash))
+        self.send_raw_transaction(
+            [&[EIP712_TX_TYPE], &*send_request.rlp_unsigned()]
+                .concat()
+                .into(),
+        )
+        .await
     }
 
     async fn send<D>(
@@ -776,7 +767,7 @@ impl<P: JsonRpcClient> ZKSProvider for Provider<P> {
         function_signature: &str,
         function_parameters: Option<Vec<String>>,
         _overrides: Option<Overrides>,
-    ) -> Result<(Vec<Token>, H256), ProviderError>
+    ) -> Result<PendingTransaction<Self::Provider>, ProviderError>
     where
         D: PrehashSigner<(RecoverableSignature, RecoveryId)> + Send + Sync,
     {
@@ -789,15 +780,7 @@ impl<P: JsonRpcClient> ZKSProvider for Provider<P> {
             _overrides,
         )
         .await?;
-        let pending_transaction = self.send_transaction(tx, None).await?;
-
-        let transaction_receipt = pending_transaction
-            .await?
-            .ok_or(ProviderError::CustomError(
-                "no transaction receipt".to_owned(),
-            ))?;
-
-        Ok((Vec::new(), transaction_receipt.transaction_hash))
+        self.send_transaction(tx, None).await
     }
 
     async fn wait_for_finalize(
@@ -1811,6 +1794,9 @@ mod tests {
                 None,
             )
             .await
+            .unwrap()
+            .await
+            .unwrap()
             .unwrap();
         let set_value =
             ZKSProvider::call(&era_provider, contract_address, "getValue()(uint256)", None)
@@ -1831,6 +1817,9 @@ mod tests {
                 None,
             )
             .await
+            .unwrap()
+            .await
+            .unwrap()
             .unwrap();
         let incremented_value =
             ZKSProvider::call(&era_provider, contract_address, "getValue()(uint256)", None)

--- a/src/zks_provider/mod.rs
+++ b/src/zks_provider/mod.rs
@@ -1338,6 +1338,9 @@ mod tests {
             )
             .await
             .unwrap()
+            .await
+            .unwrap()
+            .unwrap()
             .transaction_hash;
         let invalid_transaction_hash: H256 =
             "0x84472204e445cb3cd5f3ce5e23abcc2892cda5e61b35855a7f0bb1562a6e30e7"
@@ -1729,6 +1732,9 @@ mod tests {
                 None,
             )
             .await
+            .unwrap()
+            .await
+            .unwrap()
             .unwrap()
             .transaction_hash;
         let invalid_transaction_hash: H256 =

--- a/src/zks_wallet/wallet.rs
+++ b/src/zks_wallet/wallet.rs
@@ -188,7 +188,7 @@ where
         amount_to_transfer: U256,
         // TODO: Support multiple-token transfers.
         _token: Option<Address>,
-    ) -> Result<TransactionReceipt, ZKSWalletError<M, D>>
+    ) -> Result<PendingTransaction<M::Provider>, ZKSWalletError<M, D>>
     where
         M: ZKSProvider,
     {
@@ -227,13 +227,7 @@ where
             )
             .await?;
 
-        let transaction_receipt = pending_transaction
-            .await?
-            .ok_or(ZKSWalletError::CustomError(
-                "no transaction receipt".to_owned(),
-            ))?;
-
-        Ok(transaction_receipt)
+        Ok(pending_transaction)
     }
 
     pub async fn deposit(
@@ -886,6 +880,9 @@ mod zks_signer_tests {
         let receipt = zk_wallet
             .transfer_eip712(receiver_address, amount_to_transfer, None)
             .await
+            .unwrap()
+            .await
+            .unwrap()
             .unwrap();
 
         assert_eq!(receipt.from, zk_wallet.l2_address());


### PR DESCRIPTION
For the user to have more control over the transactions and when to `await` for the `TransactionReceipt` all the operations including `send` and `send_eip712` to send a transaction, should return the `PendingTransaction` to be awaited in the user side.