### PR TITLE
Fix signature for RLP encoding

### DIFF
--- a/src/eip712/transaction.rs
+++ b/src/eip712/transaction.rs
@@ -29,7 +29,6 @@ pub struct Eip712Transaction {
     pub data: Bytes,
     pub factory_deps: Vec<Bytes>,
     pub paymaster_input: Bytes,
-    #[serde(skip_serializing)]
     pub chain_id: U256,
 }
 

--- a/src/eip712/transaction_request.rs
+++ b/src/eip712/transaction_request.rs
@@ -4,7 +4,10 @@ use crate::{
     zks_wallet::Overrides,
 };
 use ethers::{
-    types::{transaction::eip2930::AccessList, Address, Bytes, Signature, U256, U64},
+    types::{
+        transaction::{eip2930::AccessList, eip712::Eip712Error},
+        Address, Bytes, Signature, U256,
+    },
     utils::rlp::{Encodable, RlpStream},
 };
 use serde::{Deserialize, Serialize};
@@ -155,15 +158,15 @@ impl Eip712TransactionRequest {
         self
     }
 
-    pub fn rlp_unsigned(&self) -> Bytes {
+    pub fn rlp_unsigned(&self) -> Result<Bytes, Eip712Error> {
         self.rlp(None)
     }
 
-    pub fn rlp_signed(&self, signature: Signature) -> Bytes {
+    pub fn rlp_signed(&self, signature: Signature) -> Result<Bytes, Eip712Error> {
         self.rlp(Some(signature))
     }
 
-    pub fn rlp(&self, signature: Option<Signature>) -> Bytes {
+    pub fn rlp(&self, signature: Option<Signature>) -> Result<Bytes, Eip712Error> {
         let mut stream = RlpStream::new();
         stream.begin_unbounded_list();
 
@@ -181,30 +184,31 @@ impl Eip712TransactionRequest {
         stream.append(&self.value);
         // 6
         stream.append(&self.data.0);
-        if let Some(signature) = signature {
-            // 7
-            stream.append(&U64::from(signature.v));
-            // 8
-            stream.append(&signature.r);
-            // 9
-            stream.append(&signature.s);
-        } else {
-            // 7, 8, 9 must be set even if no signature is provided.
-            // This should be the case of transaction that have a
-            // custom signature set.
-            stream.append(&"");
-            stream.append(&"");
-            stream.append(&"");
-        }
+        // 7
+        stream.append(&self.chain_id);
+        // 8
+        stream.append(&"");
+        // 9
+        stream.append(&"");
         // 10
         stream.append(&self.chain_id);
         // 11
         stream.append(&self.from);
         // 12, 13, 14, 15
-        self.custom_data.rlp_append(&mut stream);
-
+        if self.custom_data.custom_signature.clone().is_some() {
+            self.custom_data.rlp_append(&mut stream);
+        } else if let Some(signature) = signature {
+            let tx = self.clone().custom_data(
+                self.clone()
+                    .custom_data
+                    .custom_signature(signature.to_vec()),
+            );
+            tx.custom_data.rlp_append(&mut stream);
+        } else {
+            return Err(Eip712Error::Message("No signature provided".to_owned()));
+        }
         stream.finalize_unbounded_list();
-        stream.out().freeze().into()
+        Ok(stream.out().freeze().into())
     }
 }
 

--- a/src/zks_provider/mod.rs
+++ b/src/zks_provider/mod.rs
@@ -752,12 +752,11 @@ impl<P: JsonRpcClient> ZKSProvider for Provider<P> {
         send_request =
             send_request.custom_data(Eip712Meta::new().custom_signature(signature.to_vec()));
 
-        self.send_raw_transaction(
-            [&[EIP712_TX_TYPE], &*send_request.rlp_unsigned()]
-                .concat()
-                .into(),
-        )
-        .await
+        let encoded_rlp = &*send_request
+            .rlp_signed(signature)
+            .map_err(|e| ProviderError::CustomError(format!("error encoding transaction: {e}")))?;
+        self.send_raw_transaction([&[EIP712_TX_TYPE], encoded_rlp].concat().into())
+            .await
     }
 
     async fn send<D>(

--- a/src/zks_utils.rs
+++ b/src/zks_utils.rs
@@ -13,7 +13,6 @@ use std::str::FromStr;
 
 pub const ETH_CHAIN_ID: u16 = 0x9;
 pub const ERA_CHAIN_ID: u16 = 0x10E;
-pub const ERA_MEMORY_NODE_CHAIN_ID: u16 = 0x104;
 
 pub const EIP712_TX_TYPE: u8 = 0x71;
 // The large L2 gas per pubdata to sign. This gas is enough to ensure that

--- a/src/zks_utils.rs
+++ b/src/zks_utils.rs
@@ -13,6 +13,8 @@ use std::str::FromStr;
 
 pub const ETH_CHAIN_ID: u16 = 0x9;
 pub const ERA_CHAIN_ID: u16 = 0x10E;
+pub const ERA_MEMORY_NODE_CHAIN_ID: u16 = 0x104;
+
 pub const EIP712_TX_TYPE: u8 = 0x71;
 // The large L2 gas per pubdata to sign. This gas is enough to ensure that
 // any reasonable limit will be accepted. Note, that the operator is NOT required to

--- a/src/zks_wallet/wallet.rs
+++ b/src/zks_wallet/wallet.rs
@@ -219,12 +219,9 @@ where
         transfer_request =
             transfer_request.custom_data(Eip712Meta::new().custom_signature(signature.to_vec()));
 
+        let encoded_rlp = &*transfer_request.rlp_signed(signature)?;
         let pending_transaction = era_provider
-            .send_raw_transaction(
-                [&[EIP712_TX_TYPE], &*transfer_request.rlp_unsigned()]
-                    .concat()
-                    .into(),
-            )
+            .send_raw_transaction([&[EIP712_TX_TYPE], encoded_rlp].concat().into())
             .await?;
 
         Ok(pending_transaction)
@@ -372,12 +369,9 @@ where
         deploy_request =
             deploy_request.custom_data(custom_data.custom_signature(signature.to_vec()));
 
+        let encoded_rlp = &*deploy_request.rlp_signed(signature)?;
         let pending_transaction = era_provider
-            .send_raw_transaction(
-                [&[EIP712_TX_TYPE], &*deploy_request.rlp_unsigned()]
-                    .concat()
-                    .into(),
-            )
+            .send_raw_transaction([&[EIP712_TX_TYPE], encoded_rlp].concat().into())
             .await?;
 
         // TODO: Should we wait here for the transaction to be confirmed on-chain?
@@ -479,15 +473,9 @@ where
 
         let signable_data: Eip712Transaction = deploy_request.clone().try_into()?;
         let signature: Signature = self.l2_wallet.sign_typed_data(&signable_data).await?;
-        deploy_request =
-            deploy_request.custom_data(custom_data.custom_signature(signature.to_vec()));
-
+        let encoded_rlp = &*deploy_request.rlp_signed(signature)?;
         let pending_transaction = era_provider
-            .send_raw_transaction(
-                [&[EIP712_TX_TYPE], &*deploy_request.rlp_unsigned()]
-                    .concat()
-                    .into(),
-            )
+            .send_raw_transaction([&[EIP712_TX_TYPE], encoded_rlp].concat().into())
             .await?;
 
         pending_transaction


### PR DESCRIPTION
Trying to deploy in the new [`era-test-node`](https://github.com/matter-labs/era-test-node), we discovered an issue related to the signature and the RLP encoding for the transaction. This PR fixes that error, enabling deployment in both `local-setup` (docker nodes) and the new memory node.

closes #97 