### PR TITLE
feat(l2_token_addr): add a function to get the l2 token addr

### DIFF
--- a/src/contracts/l2_shared_bridge.rs
+++ b/src/contracts/l2_shared_bridge.rs
@@ -1,3 +1,32 @@
+// FIXME: Remove this after finishing the implementation.
+#![allow(clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use ethers::{abi::Address, providers::Middleware};
 use ethers_contract::abigen;
 
+use crate::ZKMiddleware;
+
 abigen!(L2SharedBridge, "abi/IL2Bridge.json");
+
+/// Gets the L2 token Address, given the L1 token Address.
+///
+/// # Returns
+///
+/// L2 token Address.
+pub async fn get_l2_token_from_l1_address<L2Provider>(
+    token: Address,
+    l2_provider: &L2Provider,
+) -> Address
+where
+    L2Provider: ZKMiddleware + Middleware + Clone + 'static,
+{
+    let bridge_addresses = l2_provider.get_bridge_contracts().await.unwrap();
+    let l2_shared_bridge_addr = bridge_addresses.l2_shared_default_bridge.unwrap();
+
+    let l2_shared_bridge =
+        L2SharedBridge::new(l2_shared_bridge_addr, Arc::new(l2_provider.clone()));
+
+    l2_shared_bridge.l_2_token_address(token).await.unwrap()
+}

--- a/tests/l2_shared_bridge.rs
+++ b/tests/l2_shared_bridge.rs
@@ -1,0 +1,19 @@
+use std::str::FromStr;
+mod common;
+use common::l2_provider;
+use zksync_ethers_rs::contracts::l2_shared_bridge::get_l2_token_from_l1_address;
+use zksync_types::H160;
+
+#[tokio::test]
+async fn l2_token_address() {
+    let l2_provider = l2_provider().await;
+    let l2_token = get_l2_token_from_l1_address(
+        H160::from_str("0x8E9C82509488eD471A83824d20Dd474b8F534a0b").unwrap(),
+        &l2_provider,
+    )
+    .await;
+    assert_eq!(
+        l2_token,
+        H160::from_str("0xb06fcdb64e4b4c18406e0d5e13ed1c7cec452716").unwrap()
+    );
+}


### PR DESCRIPTION
# Purpose
- Provide a low level implementation to interact with the `L2SharedBridge` in order to get the L2 Token Address from the L1 token Address