### PR TITLE
feat(transfer): add Overrides field that overrides nonce

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ clap = { version = "4.2.7", features = ["derive"] }
 lazy_static = "1.4.0"
 
 # ZKsync
-zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", tag = "core-v24.7.0", package = "zksync_types"}
-zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era.git", tag = "core-v24.7.0", package = "zksync_web3_decl"}
-zksync_system_constants = { git = "https://github.com/matter-labs/zksync-era.git", tag = "core-v24.7.0", package = "zksync_system_constants"}
-zksync_contracts = { git = "https://github.com/matter-labs/zksync-era.git", tag = "core-v24.7.0", package = "zksync_contracts"}
+zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", tag = "core-v24.7.0", package = "zksync_types" }
+zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era.git", tag = "core-v24.7.0", package = "zksync_web3_decl" }
+zksync_system_constants = { git = "https://github.com/matter-labs/zksync-era.git", tag = "core-v24.7.0", package = "zksync_system_constants" }
+zksync_contracts = { git = "https://github.com/matter-labs/zksync-era.git", tag = "core-v24.7.0", package = "zksync_contracts" }
 
 # Async
 tokio = { version = "1", features = ["macros", "process"] }
@@ -48,9 +48,9 @@ colored = "2.1.0"
 
 # Examples
 
-[[example]]
-name = "simple_payment"
-path = "examples/simple_payment/main.rs"
+#[[example]]
+#name = "simple_payment"
+#path = "examples/simple_payment/main.rs"
 
 [profile.test]
 opt-level = 3

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -8,7 +8,7 @@ use ethers::{
     signers::Signer,
     types::{transaction::eip2718::TypedTransaction, Eip1559TransactionRequest, U256},
 };
-use std::sync::Arc;
+use std::{ops::Mul, sync::Arc};
 use zksync_types::{L2_BASE_TOKEN_ADDRESS, MAX_L2_TX_GAS_LIMIT};
 
 use crate::{
@@ -58,9 +58,9 @@ where
         );
     // let fee = from.estimate_fee(transfer_tx.clone()).await.unwrap();
     transfer_tx = transfer_tx
-        .max_fee_per_gas(MAX_FEE_PER_GAS)
-        .max_priority_fee_per_gas(MAX_PRIORITY_FEE_PER_GAS)
-        .gas(MAX_L2_TX_GAS_LIMIT);
+        .max_fee_per_gas(MAX_FEE_PER_GAS.mul(100))
+        .max_priority_fee_per_gas(MAX_PRIORITY_FEE_PER_GAS.mul(100))
+        .gas(MAX_L2_TX_GAS_LIMIT.mul(10));
 
     let tx: TypedTransaction = transfer_tx.into();
 

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -14,6 +14,7 @@ use zksync_types::{L2_BASE_TOKEN_ADDRESS, MAX_L2_TX_GAS_LIMIT};
 use crate::{
     contracts::erc20::ERC20,
     utils::{MAX_FEE_PER_GAS, MAX_PRIORITY_FEE_PER_GAS},
+    ZKMiddleware,
 };
 
 pub async fn transfer<M, S>(
@@ -57,10 +58,11 @@ where
                 .unwrap(),
         );
     // let fee = from.estimate_fee(transfer_tx.clone()).await.unwrap();
+    let gas = from.provider().estimate_fee(&transfer_tx).await.unwrap();
     transfer_tx = transfer_tx
-        .max_fee_per_gas(MAX_FEE_PER_GAS.mul(100))
-        .max_priority_fee_per_gas(MAX_PRIORITY_FEE_PER_GAS.mul(100))
-        .gas(MAX_L2_TX_GAS_LIMIT.mul(10));
+        .max_fee_per_gas(gas.max_fee_per_gas)
+        .max_priority_fee_per_gas(gas.max_priority_fee_per_gas)
+        .gas(gas.gas_limit);
 
     let tx: TypedTransaction = transfer_tx.into();
 

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -11,14 +11,14 @@ use ethers::{
 use std::sync::Arc;
 use zksync_types::L2_BASE_TOKEN_ADDRESS;
 
-use crate::{contracts::erc20::ERC20, ZKMiddleware};
+use crate::{contracts::erc20::ERC20, types::L2TxOverrides, ZKMiddleware};
 
 pub async fn transfer<M, S>(
     amount: U256,
     token: impl Into<Address>,
     from: Arc<SignerMiddleware<M, S>>,
     to: Address,
-    overrides: Option<Overrides>,
+    overrides: Option<L2TxOverrides>,
 ) -> Hash
 where
     M: Middleware,
@@ -36,32 +36,12 @@ where
     }
 }
 
-pub struct Overrides {
-    pub nonce: Option<U256>,
-}
-
-impl Overrides {
-    pub fn new() -> Self {
-        Overrides { nonce: None }
-    }
-    pub fn with_nonce(mut self, nonce: U256) -> Self {
-        self.nonce = Some(nonce);
-        self
-    }
-}
-
-impl Default for Overrides {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 ///  The fee has to be deducted manually, amount is the exact amount that has to be transferred
 pub async fn transfer_base_token<M, S>(
     amount: U256,
     from: Arc<SignerMiddleware<M, S>>,
     to: Address,
-    overrides: Option<Overrides>,
+    overrides: Option<L2TxOverrides>,
 ) -> Hash
 where
     M: Middleware,

--- a/src/types.rs
+++ b/src/types.rs
@@ -49,3 +49,44 @@ impl L1TxOverrides {
         self
     }
 }
+
+#[derive(Debug, Clone, Default)]
+pub struct L2TxOverrides {
+    pub from: Option<Address>,
+    pub value: Option<U256>,
+    pub gas_price: Option<U256>,
+    pub gas: Option<U256>,
+    pub nonce: Option<U256>,
+    pub gas_limit: Option<U256>,
+}
+
+impl L2TxOverrides {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn from(mut self, from: Address) -> Self {
+        self.from = Some(from);
+        self
+    }
+
+    pub fn value(mut self, value: U256) -> Self {
+        self.value = Some(value);
+        self
+    }
+
+    pub fn gas_price(mut self, gas_price: U256) -> Self {
+        self.gas_price = Some(gas_price);
+        self
+    }
+
+    pub fn gas(mut self, gas: U256) -> Self {
+        self.gas = Some(gas);
+        self
+    }
+
+    pub fn nonce(mut self, nonce: U256) -> Self {
+        self.nonce = Some(nonce);
+        self
+    }
+}

--- a/src/withdraw.rs
+++ b/src/withdraw.rs
@@ -183,11 +183,16 @@ where
         )
         .await
         .unwrap()
-        .unwrap()
+        .unwrap();
+
+    let withdrawal_msg_index = withdrawal_initialization_log_merkle_proof.id;
+
+    let withdrawal_initialization_log_merkle_proof = withdrawal_initialization_log_merkle_proof
         .proof
         .into_iter()
         .map(Into::into)
         .collect::<Vec<_>>();
+
     let l2_batch_number = withdrawal_initialization_tx_l2_to_l1_logs
         .iter()
         .find(|log| log.sender == L1_MESSENGER_ADDRESS)
@@ -201,7 +206,7 @@ where
         .finalize_withdrawal(
             zk_chain_id.into(),
             l2_batch_number.as_u64().into(),
-            U256::zero(),
+            withdrawal_msg_index.into(),
             withdrawal_initialization_tx_number_in_batch,
             withdrawal_initialization_message,
             withdrawal_initialization_log_merkle_proof,

--- a/src/zk_wallet.rs
+++ b/src/zk_wallet.rs
@@ -9,10 +9,7 @@ use std::sync::Arc;
 use zksync_types::L2_BASE_TOKEN_ADDRESS;
 
 use crate::{
-    deposit,
-    transfer::{self, Overrides},
-    utils::L2_ETH_TOKEN_ADDRESS,
-    withdraw, ZKMiddleware,
+    deposit, transfer, types::L2TxOverrides, utils::L2_ETH_TOKEN_ADDRESS, withdraw, ZKMiddleware,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -286,7 +283,7 @@ where
         &self,
         amount: U256,
         to: Address,
-        overrides: Option<Overrides>,
+        overrides: Option<L2TxOverrides>,
     ) -> Result<Hash, ZKWalletError> {
         self._transfer(amount, L2_ETH_TOKEN_ADDRESS, to, overrides)
             .await
@@ -315,7 +312,7 @@ where
         amount: U256,
         token: Address,
         to: Address,
-        overrides: Option<Overrides>,
+        overrides: Option<L2TxOverrides>,
     ) -> Result<Hash, ZKWalletError> {
         self._transfer(amount, token, to, overrides).await
     }
@@ -340,7 +337,7 @@ where
         &self,
         amount: U256,
         to: Address,
-        overrides: Option<Overrides>,
+        overrides: Option<L2TxOverrides>,
     ) -> Result<Hash, ZKWalletError> {
         self._transfer(amount, L2_BASE_TOKEN_ADDRESS, to, overrides)
             .await
@@ -499,7 +496,7 @@ where
         amount: U256,
         token: Address,
         to: Address,
-        overrides: Option<Overrides>,
+        overrides: Option<L2TxOverrides>,
     ) -> Result<Hash, ZKWalletError> {
         let transfer_hash =
             transfer::transfer(amount, token, self.l2_signer(), to, overrides).await;


### PR DESCRIPTION
# Purpose
- Add a way to override the `nonce`.
- Ask the RPC for the `fee/gas limits`
- Use the `log_merkle_proof.id` in the `withdraw` transaction

Comment: 
Since this library is mainly a low level abstraction to interact with a zkStack chain, the gas+fees has to be deducted by the programmer, manually, whenever a `transfer`/`deposit`/`withdraw` is performed. 